### PR TITLE
adding missing packages to browser app dependencies

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -2,10 +2,13 @@
   "name": "browser",
   "version": "0.0.0",
   "dependencies": {
+    "baconjs": "^0.7.53",
     "gulp": "^3.8.11",
     "gulp-util": "^3.0.4",
     "gulp-webpack": "^1.4.0",
     "gulp-webpack-build": "^0.11.0",
+    "immutable": "^3.7.3",
+    "lodash": "^3.6.0",
     "node-libs-browser": "^0.5.2",
     "webpack": "^1.9.10",
     "webpack-dev-server": "^1.9.0"


### PR DESCRIPTION
Running "gulp" in the browser folder is broken without these.